### PR TITLE
Precision of tol for float has been changed

### DIFF
--- a/matrix/PseudoInverse.hxx
+++ b/matrix/PseudoInverse.hxx
@@ -14,7 +14,7 @@
 template<typename Type>
 void fullRankCholeskyTolerance(Type &tol)
 {
-    tol /= 1000000000;
+    tol /= 10000000;
 }
 
 template<> inline


### PR DESCRIPTION
There were some cases that the results of pseudo inv becomes a null matrix when the input matrix is a floating-point number matrix such as follow: 
![image](https://user-images.githubusercontent.com/56542570/98004421-41245e80-1e33-11eb-918d-a485d01b7486.png)
As a result, the actuators output unexpected values as follow:
![image](https://user-images.githubusercontent.com/56542570/98005038-fa833400-1e33-11eb-9b3f-0dace1a9cd2d.png)

I found out that the problem occurs as the precision of the tolerance for the float variables is too big, which is bigger than typical floating number precision(typically 7, reference: https://www.learncpp.com/cpp-tutorial/floating-point-numbers/).

So I simply decreased the precision for 2 digits and was able to obtain the following result:
![image](https://user-images.githubusercontent.com/56542570/98006063-26eb8000-1e35-11eb-982e-147658076805.png)
and the typical actuator outputs log as follow:
![image](https://user-images.githubusercontent.com/56542570/98006345-75991a00-1e35-11eb-824e-0925043c7f6e.png)


