### PR TITLE
Coerce default epsilon values to Type

### DIFF
--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -605,7 +605,7 @@ Matrix<Type, M, N> operator*(Type scalar, const Matrix<Type, M, N> &other)
 
 template<typename Type, size_t  M, size_t N>
 bool isEqual(const Matrix<Type, M, N> &x,
-             const Matrix<Type, M, N> &y, const Type eps=1e-4f) {
+             const Matrix<Type, M, N> &y, const Type eps=Type(1e-4f)) {
     for (size_t i = 0; i < M; i++) {
         for (size_t j = 0; j < N; j++) {
             if (!isEqualF(x(i,j), y(i,j), eps)) {

--- a/matrix/SquareMatrix.hpp
+++ b/matrix/SquareMatrix.hpp
@@ -223,7 +223,7 @@ public:
 
     // checks if block diagonal is symmetric
     template <size_t Width>
-    bool isBlockSymmetric(size_t first, const Type eps = 1e-8f)
+    bool isBlockSymmetric(size_t first, const Type eps = Type(1e-8f))
     {
         static_assert(Width <= M, "Width bigger than matrix");
         assert(first + Width <= M);
@@ -243,7 +243,7 @@ public:
 
     // checks if rows and columns are symmetric
     template <size_t Width>
-    bool isRowColSymmetric(size_t first, const Type eps = 1e-8f)
+    bool isRowColSymmetric(size_t first, const Type eps = Type(1e-8f))
     {
         static_assert(Width <= M, "Width bigger than matrix");
         assert(first + Width <= M);
@@ -324,7 +324,7 @@ bool inv(const SquareMatrix<Type, M> & A, SquareMatrix<Type, M> & inv, size_t ra
             for (size_t i = n + 1; i < rank; i++) {
 
                 //printf("\ttrying row %d\n",i);
-                if (fabs(static_cast<float>(U(i, n))) > 1e-8f) {
+                if (fabs(static_cast<float>(U(i, n))) > Type(1e-8f)) {
                     //printf("swapped %d\n",i);
                     U.swapRows(i, n);
                     P.swapRows(i, n);

--- a/matrix/helper_functions.hpp
+++ b/matrix/helper_functions.hpp
@@ -32,7 +32,7 @@ bool is_finite(Type x) {
  * @return true if the two values are considered equal, false otherwise
  */
 template<typename Type>
-bool isEqualF(const Type x, const Type y, const Type eps = 1e-4f)
+bool isEqualF(const Type x, const Type y, const Type eps = Type(1e-4f))
 {
     return (matrix::fabs(x - y) <= eps)
            || (isnan(x) && isnan(y))


### PR DESCRIPTION
In order for some builds to work where the Type is double, we need to manually coerce the type so that we don't get compiler warnings of implicit float -> double conversions