### PR TITLE
Type coercion cleanup

### DIFF
--- a/matrix/SquareMatrix.hpp
+++ b/matrix/SquareMatrix.hpp
@@ -319,12 +319,12 @@ bool inv(const SquareMatrix<Type, M> & A, SquareMatrix<Type, M> & inv, size_t ra
     for (size_t n = 0; n < rank; n++) {
 
         // if diagonal is zero, swap with row below
-        if (fabs(static_cast<float>(U(n, n))) < FLT_EPSILON) {
+        if (fabs(U(n, n)) < Type(FLT_EPSILON)) {
             //printf("trying pivot for row %d\n",n);
             for (size_t i = n + 1; i < rank; i++) {
 
                 //printf("\ttrying row %d\n",i);
-                if (fabs(static_cast<float>(U(i, n))) > Type(1e-8f)) {
+                if (fabs(U(i, n)) > Type(FLT_EPSILON)) {
                     //printf("swapped %d\n",i);
                     U.swapRows(i, n);
                     P.swapRows(i, n);

--- a/test/matrixAssignment.cpp
+++ b/test/matrixAssignment.cpp
@@ -226,7 +226,7 @@ int main()
     printf("%s\n", output); // for debugging in case of failure
     for (size_t i = 0; i < len; i++) {
         if(buffer[i] != output[i]) { // for debugging in case of failure
-            printf("%d: \"%c\" != \"%c\"", int(i), buffer[i], output[i]);
+            printf("%d: \"%c\" != \"%c\"", int(i), buffer[i], output[i]); // LCOV_EXCL_LINE only print on failure
         }
         TEST(buffer[i] == output[i]);
         if (buffer[i] == '\0') {


### PR DESCRIPTION
Fix some compiler warnings and inconsistencies in the algorithm. Also ignore a line in the coverage which shouldn't happen anyways.